### PR TITLE
De-indent `type Types` definition.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,12 +305,12 @@ struct PlungerQueue<Ctx> {
 }
 
 type Types<Ctx> = dyn pin_list::Types<
-        Id = pin_list::id::DebugChecked,
-        Protected = job::RawDynJob<Ctx>,
-        Acquired = bool,
-        Released = job::JobComplete,
-        Unprotected = DiatomicWaker,
-    >;
+    Id = pin_list::id::DebugChecked,
+    Protected = job::RawDynJob<Ctx>,
+    Acquired = bool,
+    Released = job::JobComplete,
+    Unprotected = DiatomicWaker,
+>;
 
 enum Shutdown<Ctx> {
     Drop,


### PR DESCRIPTION
It seems to have been accidentally indented one extra time. Noticed while reading the code so I figured I'd fix it while I'm at it :)