### PR TITLE
Remove object lifetime cast

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -25,7 +25,14 @@ impl<Ctx> RawDynJob<Ctx> {
         F: JobErased<Ctx> + Send,
     {
         let job = NonNull::from(job.get()).as_ptr().cast::<F>();
-        Self { job: job as _ }
+        Self {
+            job: unsafe {
+                std::mem::transmute::<
+                    *mut (dyn JobErased<Ctx> + Send + '_),
+                    *mut (dyn JobErased<Ctx> + Send + 'static),
+                >(job)
+            },
+        }
     }
 
     pub(super) fn run_job(


### PR DESCRIPTION
There is an ongoing effort to remove lifetime casts on trait objects from the language. Please see: https://github.com/rust-lang/rust/pull/136776

Using a transmute to perform the relevant pointer cast is the recommended replacement.